### PR TITLE
fix typo of `haveValues` in Map Matcher

### DIFF
--- a/guide/src/test/scala/org/specs2/guide/matchers/MapMatchers.scala
+++ b/guide/src/test/scala/org/specs2/guide/matchers/MapMatchers.scala
@@ -19,7 +19,7 @@ Maps have their own matchers as well, to check keys and values:
    `Map(1 -> "1") must haveValue("1")`
 
  * `haveValues` check if a Map has several values
-   `Map(1 -> "1", 2 -> "2") must haveValue("1", "2")`
+   `Map(1 -> "1", 2 -> "2") must haveValues("1", "2")`
 
  * `havePair` check if a Map has a given pair of values
    `Map(1 -> "1") must havePair(1 -> "1")`


### PR DESCRIPTION
fixing a typo on `haveValues` Matcher in Map
